### PR TITLE
Fix jpeg-turbo's library path to homebrew's recommended value.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       "sources": [ "jpeg.cc", "scaling.cc" ],
       "include_dirs": [ "/usr/local/opt/jpeg-turbo/include" ],
       "link_settings": {
-        "libraries": [ "-L/usr/local/Cellar/jpeg-turbo/1.4.0/lib", "-lturbojpeg" ]
+        "libraries": [ "-L/usr/local/opt/jpeg-turbo/lib", "-lturbojpeg" ]
       },
 
   },


### PR DESCRIPTION
Fixes a build failure on OS X since the latest version of jpeg-turbo is 1.4.1 now.
